### PR TITLE
Add usage of test stream over command line arguments

### DIFF
--- a/config.c
+++ b/config.c
@@ -36,6 +36,7 @@ cVNSIServerConfig::cVNSIServerConfig()
   ConfigDirectory     = NULL;
   stream_timeout      = 10;
   device              = false;
+  testStreamActive    = false;
 }
 
 /* Global instance */

--- a/config.h
+++ b/config.h
@@ -79,6 +79,8 @@ public:
   uint16_t listen_port;         // Port of remote server
   uint16_t stream_timeout;      // timeout in seconds for stream data
   bool device;                  // true if vnsi should act as dummy device
+  cString testStreamFile;       // TS file to simulate channel
+  bool testStreamActive;        // true if test mode is enabled
 };
 
 // Global instance

--- a/streamer.c
+++ b/streamer.c
@@ -88,10 +88,10 @@ bool cLiveStreamer::Open(int serial)
     return false;
 
   bool recording = false;
-  if (0) // test harness
+  if (VNSIServerConfig.testStreamActive) // test harness
   {
     recording = true;
-    m_VideoBuffer = cVideoBuffer::Create("/home/xbmc/test.ts");
+    m_VideoBuffer = cVideoBuffer::Create(VNSIServerConfig.testStreamFile);
   }
   else if (PlayRecording && serial == -1)
   {

--- a/vnsi.c
+++ b/vnsi.c
@@ -45,7 +45,8 @@ cPluginVNSIServer::~cPluginVNSIServer()
 
 const char *cPluginVNSIServer::CommandLineHelp(void)
 {
-    return "  -t n, --timeout=n      stream data timeout in seconds (default: 10)\n";
+    return "  -t n, --timeout=n      stream data timeout in seconds (default: 10)\n"
+           "  -s n, --test=n         TS stream test file to simulate as channel\n";
 }
 
 bool cPluginVNSIServer::ProcessArgs(int argc, char *argv[])
@@ -54,16 +55,29 @@ bool cPluginVNSIServer::ProcessArgs(int argc, char *argv[])
   static struct option long_options[] = {
        { "timeout",  required_argument, NULL, 't' },
        { "device",   no_argument,       NULL, 'd' },
+       { "test",     required_argument, NULL, 'T' },
        { NULL,       no_argument,       NULL,  0  }
      };
 
   int c;
 
-  while ((c = getopt_long(argc, argv, "t:d", long_options, NULL)) != -1) {
+  while ((c = getopt_long(argc, argv, "t:d:T:", long_options, NULL)) != -1) {
         switch (c) {
           case 't': if(optarg != NULL) VNSIServerConfig.stream_timeout = atoi(optarg);
                     break;
           case 'd': VNSIServerConfig.device = true;
+                    break;
+          case 'T': if(optarg != NULL) {
+                    VNSIServerConfig.testStreamFile = optarg;
+
+                    struct stat file_stat;
+                    if (stat(VNSIServerConfig.testStreamFile, &file_stat) == 0) {
+                      VNSIServerConfig.testStreamActive = true;
+                      printf("vnsiserver: requested test stream file '%s' played now on all channels\n", *VNSIServerConfig.testStreamFile);
+                      }
+                    else
+                      printf("vnsiserver: requested test stream file '%s' not present, started without\n", *VNSIServerConfig.testStreamFile);
+                      }
                     break;
           default:  return false;
           }


### PR DESCRIPTION
Hello @FernetMenta,

long time ago about a change from me there. With this it become possible to use a test stream file without compile of plugin again.

I use this currently for radio test stream to become RDS data from it.

Best regards,

Alwin
