### PR TITLE
Compiler throws conversion warning

### DIFF
--- a/responsepacket.c
+++ b/responsepacket.c
@@ -213,7 +213,7 @@ bool cResponsePacket::copyin(const uint8_t* src, uint32_t len)
 }
 
 uint8_t* cResponsePacket::reserve(uint32_t len) {
-  if (!checkExtend(len)) return false;
+  if (!checkExtend(len)) return 0;
   uint8_t* result = buffer + bufUsed;
   bufUsed += len;
   return result;


### PR DESCRIPTION
gcc 4.8.3 on Gentoo threw the following:

> responsepacket.c: In member function ‘uint8_t\* cResponsePacket::reserve(uint32_t)’:
> responsepacket.c:216:33: warning: converting ‘false’ to pointer type ‘uint8_t\* {aka unsigned char*}’ # [-Wconversion-null]
>   if (!checkExtend(len)) return false;

This fixed it for me and as of my knowledge, it should result in the same behavior. Please correct me, in case i am wrong.
