### PR TITLE
Add support of deleted and reproducable recordings

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -1,6 +1,10 @@
 VDR Plugin 'vnsiserver' Revision History
 ----------------------------------------
 
+2015-02-07: Version 1.3.0
+
+- add support for undelete recordings
+
 2015-01-25: Version 1.2.1
 
 - add cmd line switch for setting tcp port

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -1,0 +1,61 @@
+# VDR VNSI plugin language source file.
+# Copyright (C) 2015 Alwin Esch
+# This file is distributed under the same license as the VDR package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: VNSI-Server 1.0.0\n"
+"Report-Msgid-Bugs-To: <see README>\n"
+"POT-Creation-Date: 2015-01-23 22:25+0100\n"
+"PO-Revision-Date: 2015-01-23 21:46+0100\n"
+"Last-Translator: Alwin Esch\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=ISO-8859-15\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "PMT Timeout (0-10)"
+msgstr "PMT Auszeit (0-10)"
+
+msgid "Off"
+msgstr "Aus"
+
+msgid "RAM"
+msgstr "RAM"
+
+msgid "File"
+msgstr "Datei"
+
+msgid "Time Shift Mode"
+msgstr "Time Shift Modus"
+
+msgid "TS Buffersize (RAM) (1-80) x 100MB"
+msgstr "TS Puffergröße (RAM) (1-80) x 100MB"
+
+msgid "TS Buffersize (File) (1-10) x 1GB"
+msgstr "TS Puffergröße (Datei) (1-10) x 1GB"
+
+msgid "TS Buffer Directory"
+msgstr "TS-Puffer-Verzeichnis"
+
+msgid "Play Recording instead of live"
+msgstr "Wiedergeben als Aufzeichnung statt Live"
+
+msgid "Avoid EPG scan while streaming"
+msgstr "Keine EPG suche während der Wiedergabe durchführen"
+
+msgid "Recording with the same name exists"
+msgstr "Aufnahme mit der selben größe existiert"
+
+msgid "Error while read last filenumber"
+msgstr "Fehler beim lesen der letzen Dateinummer"
+
+msgid "Error while accessing vdrfile"
+msgstr "Fehler beim zugriff auf VDR-Datei"
+
+msgid "Error while accessing indexfile"
+msgstr "Fehler beim Zugriff der Indexdatei"
+
+msgid "Deleted recording vanished"
+msgstr "Gelöschte Aufnahme verschwunden"

--- a/recordingscache.h
+++ b/recordingscache.h
@@ -40,13 +40,17 @@ public:
 
   static cRecordingsCache& GetInstance();
 
-  uint32_t Register(cRecording* recording);
+  uint32_t Register(cRecording* recording, bool deleted = false);
 
   cRecording* Lookup(uint32_t uid);
 
 private:
-
-  std::map<uint32_t, cString> m_recordings;
+  struct RecordingsInfo
+  {
+    cString filename;
+    bool isDeleted;
+  };
+  std::map<uint32_t, RecordingsInfo> m_recordings;
 
   cMutex m_mutex;
 };

--- a/vnsi.h
+++ b/vnsi.h
@@ -26,7 +26,7 @@
 #include <vdr/plugin.h>
 #include "vnsiserver.h"
 
-static const char *VERSION        = "1.2.1";
+static const char *VERSION        = "1.3.0";
 static const char *DESCRIPTION    = "VDR-Network-Streaming-Interface (VNSI) Server";
 
 extern int PmtTimeout;

--- a/vnsiclient.h
+++ b/vnsiclient.h
@@ -159,6 +159,12 @@ private:
   bool processRECORDINGS_Delete();
   bool processRECORDINGS_Move();
   bool processRECORDINGS_GetEdl();
+  bool processRECORDINGS_DELETED_Supported();
+  bool processRECORDINGS_DELETED_GetCount();
+  bool processRECORDINGS_DELETED_GetList();
+  bool processRECORDINGS_DELETED_Delete();
+  bool processRECORDINGS_DELETED_Undelete();
+  bool processRECORDINGS_DELETED_DeleteAll();
 
   bool processEPG_GetForChannel();
 
@@ -167,6 +173,8 @@ private:
   bool processSCAN_GetSatellites();
   bool processSCAN_Start();
   bool processSCAN_Stop();
+
+  bool Undelete(cRecording* recording);
 
   /** Static callback functions to interact with wirbelscan plugin over
       the plugin service interface */

--- a/vnsicommand.h
+++ b/vnsicommand.h
@@ -26,7 +26,7 @@
 #define VNSI_COMMAND_H
 
 /** Current VNSI Protocol Version number */
-#define VNSI_PROTOCOLVERSION 6
+#define VNSI_PROTOCOLVERSION 7
 
 /** Minimum VNSI Protocol Version number */
 #define VNSI_MIN_PROTOCOLVERSION 5
@@ -114,6 +114,14 @@
 #define VNSI_OSD_CONNECT           160
 #define VNSI_OSD_DISCONNECT        161
 #define VNSI_OSD_HITKEY            162
+
+/* OPCODE 180 - 189: VNSI network functions for deleted recording access */
+#define VNSI_RECORDINGS_DELETED_ACCESS_SUPPORTED 180
+#define VNSI_RECORDINGS_DELETED_GETCOUNT         181
+#define VNSI_RECORDINGS_DELETED_GETLIST          182
+#define VNSI_RECORDINGS_DELETED_DELETE           183
+#define VNSI_RECORDINGS_DELETED_UNDELETE         184
+#define VNSI_RECORDINGS_DELETED_DELETE_ALL       185
 
 /** Stream packet types (server -> client) */
 #define VNSI_STREAM_CHANGE       1


### PR DESCRIPTION
This change add support to plugin for undelete of recordings.

Due to add of new stream functions is it backword compatible to other KODI addons.

Related undelete Pull Request:
KODI: https://github.com/xbmc/xbmc/pull/6326
Addons: https://github.com/opdenkamp/xbmc-pvr-addons/pull/427