### PR TITLE
Add RDS stream support

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -4,6 +4,7 @@ VDR Plugin 'vnsiserver' Revision History
 2015-02-07: Version 1.3.0
 
 - add support for undelete recordings
+- add support for rds data if present on dvb radio and send to addon if supported there
 
 2015-01-25: Version 1.2.1
 

--- a/demuxer.c
+++ b/demuxer.c
@@ -27,7 +27,8 @@
 #include <vdr/channels.h>
 #include <libsi/si.h>
 
-cVNSIDemuxer::cVNSIDemuxer()
+cVNSIDemuxer::cVNSIDemuxer(bool bAllowRDS)
+ : m_bAllowRDS(bAllowRDS)
 {
   m_OldPmtVersion = -1;
 }
@@ -532,7 +533,7 @@ void cVNSIDemuxer::SetChannelStreams(const cChannel *channel)
       else if (channel->Atype(index) == 0x11)
         newStream.type = stAACLATM;
 #endif
-      newStream.handleRDS = newStream.type == stMPEG2AUDIO && !containsVideo ? true : false; // Relevant for RDS, if present only on mpeg 2 audio
+      newStream.handleRDS = m_bAllowRDS && newStream.type == stMPEG2AUDIO && !containsVideo ? true : false; // Relevant for RDS, if present only on mpeg 2 audio, use only if RDS is allowed
       newStream.SetLanguage(channel->Alang(index));
       AddStreamInfo(newStream);
     }

--- a/demuxer.h
+++ b/demuxer.h
@@ -51,7 +51,7 @@ struct sStreamInfo
 class cVNSIDemuxer
 {
 public:
-  cVNSIDemuxer();
+  cVNSIDemuxer(bool bAllowRDS);
   virtual ~cVNSIDemuxer();
   int Read(sStreamPacket *packet, sStreamPacket *packet_side_data);
   cTSStream *GetFirstStream();
@@ -87,4 +87,5 @@ protected:
   uint16_t m_Error;
   bool m_SetRefTime;
   time_t m_refTime, m_endTime, m_wrapTime;
+  bool m_bAllowRDS;
 };

--- a/demuxer.h
+++ b/demuxer.h
@@ -38,6 +38,7 @@ struct sStreamInfo
   int subtitlingType;
   int compositionPageId;
   int ancillaryPageId;
+  bool handleRDS;
   void SetLanguage(const char* lang)
   {
     language[0] = lang[0];
@@ -52,7 +53,7 @@ class cVNSIDemuxer
 public:
   cVNSIDemuxer();
   virtual ~cVNSIDemuxer();
-  int Read(sStreamPacket *packet);
+  int Read(sStreamPacket *packet, sStreamPacket *packet_side_data);
   cTSStream *GetFirstStream();
   cTSStream *GetNextStream();
   void Open(const cChannel &channel, cVideoBuffer *videoBuffer);

--- a/parser_AAC.c
+++ b/parser_AAC.c
@@ -58,7 +58,7 @@ cParserAAC::~cParserAAC()
 
 }
 
-void cParserAAC::Parse(sStreamPacket *pkt)
+void cParserAAC::Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data)
 {
   int p = m_PesParserPtr;
   int l;

--- a/parser_AAC.h
+++ b/parser_AAC.h
@@ -51,7 +51,7 @@ private:
 public:
   cParserAAC(int pID, cTSStream *stream, sPtsWrap *ptsWrap, bool observePtsWraps);
   virtual ~cParserAAC();
-  virtual void Parse(sStreamPacket *pkt);
+  virtual void Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data);
   virtual void Reset();
 };
 

--- a/parser_AC3.c
+++ b/parser_AC3.c
@@ -121,7 +121,7 @@ cParserAC3::~cParserAC3()
 {
 }
 
-void cParserAC3::Parse(sStreamPacket *pkt)
+void cParserAC3::Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data)
 {
   int p = m_PesParserPtr;
   int l;

--- a/parser_AC3.h
+++ b/parser_AC3.h
@@ -42,7 +42,7 @@ public:
   cParserAC3(int pID, cTSStream *stream, sPtsWrap *ptsWrap, bool observePtsWraps);
   virtual ~cParserAC3();
 
-  virtual void Parse(sStreamPacket *pkt);
+  virtual void Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data);
   virtual void Reset();
 };
 

--- a/parser_DTS.c
+++ b/parser_DTS.c
@@ -34,7 +34,7 @@ cParserDTS::~cParserDTS()
 {
 }
 
-void cParserDTS::Parse(sStreamPacket *pkt)
+void cParserDTS::Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data)
 {
 
 }

--- a/parser_DTS.h
+++ b/parser_DTS.h
@@ -33,7 +33,7 @@ public:
   cParserDTS(int pID, cTSStream *stream, sPtsWrap *ptsWrap, bool observePtsWraps);
   virtual ~cParserDTS();
 
-  virtual void Parse(sStreamPacket *pkt);
+  virtual void Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data);
 };
 
 

--- a/parser_MPEGAudio.h
+++ b/parser_MPEGAudio.h
@@ -36,13 +36,20 @@ private:
   int64_t     m_PTS;
   int64_t     m_DTS;
 
+  bool        m_RDSEnabled;
+  uint32_t    m_RDSExtPID;
+  uint8_t    *m_RDSBuffer;
+  int         m_RDSBufferSize;
+  int         m_RDSBufferPtr;
+  size_t      m_RDSBufferInitialSize;
+
   int FindHeaders(uint8_t *buf, int buf_size);
 
 public:
-  cParserMPEG2Audio(int pID, cTSStream *stream, sPtsWrap *ptsWrap, bool observePtsWraps);
+  cParserMPEG2Audio(int pID, cTSStream *stream, sPtsWrap *ptsWrap, bool observePtsWraps, bool enableRDS);
   virtual ~cParserMPEG2Audio();
 
-  virtual void Parse(sStreamPacket *pkt);
+  virtual void Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data);
 };
 
 

--- a/parser_MPEGVideo.c
+++ b/parser_MPEGVideo.c
@@ -67,7 +67,7 @@ cParserMPEG2Video::~cParserMPEG2Video()
 {
 }
 
-void cParserMPEG2Video::Parse(sStreamPacket *pkt)
+void cParserMPEG2Video::Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data)
 {
   if (m_PesBufferPtr < 4)
     return;

--- a/parser_MPEGVideo.h
+++ b/parser_MPEGVideo.h
@@ -56,7 +56,7 @@ public:
   cParserMPEG2Video(int pID, cTSStream *stream, sPtsWrap *ptsWrap, bool observePtsWraps);
   virtual ~cParserMPEG2Video();
 
-  virtual void Parse(sStreamPacket *pkt);
+  virtual void Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data);
   virtual void Reset();
 };
 

--- a/parser_Subtitle.c
+++ b/parser_Subtitle.c
@@ -35,7 +35,7 @@ cParserSubtitle::~cParserSubtitle()
 
 }
 
-void cParserSubtitle::Parse(sStreamPacket *pkt)
+void cParserSubtitle::Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data)
 {
   int l = m_PesBufferPtr;
 

--- a/parser_Subtitle.h
+++ b/parser_Subtitle.h
@@ -31,7 +31,7 @@ public:
   cParserSubtitle(int pID, cTSStream *stream, sPtsWrap *ptsWrap, bool observePtsWraps);
   virtual ~cParserSubtitle();
 
-  virtual void Parse(sStreamPacket *pkt);
+  virtual void Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data);
 };
 
 

--- a/parser_Teletext.c
+++ b/parser_Teletext.c
@@ -33,7 +33,7 @@ cParserTeletext::~cParserTeletext()
 {
 }
 
-void cParserTeletext::Parse(sStreamPacket *pkt)
+void cParserTeletext::Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data)
 {
   int l = m_PesBufferPtr;
   if (l < 1)

--- a/parser_Teletext.h
+++ b/parser_Teletext.h
@@ -35,7 +35,7 @@ public:
   cParserTeletext(int pID, cTSStream *stream, sPtsWrap *ptsWrap, bool observePtsWraps);
   virtual ~cParserTeletext();
 
-  virtual void Parse(sStreamPacket *pkt);
+  virtual void Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data);
 };
 
 #endif // VNSI_DEMUXER_TELETEXT_H

--- a/parser_h264.c
+++ b/parser_h264.c
@@ -68,7 +68,7 @@ cParserH264::~cParserH264()
 {
 }
 
-void cParserH264::Parse(sStreamPacket *pkt)
+void cParserH264::Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data)
 {
   if (m_PesBufferPtr < 4)
     return;

--- a/parser_h264.h
+++ b/parser_h264.h
@@ -108,7 +108,7 @@ public:
   cParserH264(int pID, cTSStream *stream, sPtsWrap *ptsWrap, bool observePtsWraps);
   virtual ~cParserH264();
 
-  virtual void Parse(sStreamPacket *pkt);
+  virtual void Parse(sStreamPacket *pkt, sStreamPacket *pkt_side_data);
   virtual void Reset();
 };
 

--- a/streamer.c
+++ b/streamer.c
@@ -167,32 +167,53 @@ void cLiveStreamer::Close(void)
 void cLiveStreamer::Action(void)
 {
   int ret;
-  sStreamPacket pkt;
-  memset(&pkt, 0, sizeof(sStreamPacket));
-  bool requestStreamChange = false;
+  sStreamPacket pkt_data;
+  sStreamPacket pkt_side_data; // Additional data
+  memset(&pkt_data, 0, sizeof(sStreamPacket));
+  memset(&pkt_side_data, 0, sizeof(sStreamPacket));
+  bool requestStreamChangeStdData = false;
+  bool requestStreamChangeExtData= false;
   cTimeMs last_info(1000);
   cTimeMs bufferStatsTimer(1000);
 
   while (Running())
   {
-    ret = m_Demuxer.Read(&pkt);
+    ret = m_Demuxer.Read(&pkt_data, &pkt_side_data);
     if (ret > 0)
     {
-      if (pkt.pmtChange)
+      if (pkt_data.pmtChange)
       {
-        requestStreamChange = true;
+        requestStreamChangeStdData = true;
+        requestStreamChangeExtData = true;
       }
-      if (pkt.data)
+
+      // Process normal data if present
+      if (pkt_data.data)
       {
-        if (pkt.streamChange || requestStreamChange)
+        if (pkt_data.streamChange || requestStreamChangeStdData)
           sendStreamChange();
-        requestStreamChange = false;
-        if (pkt.reftime)
+        requestStreamChangeStdData = false;
+        if (pkt_data.reftime)
         {
-          sendRefTime(&pkt);
-          pkt.reftime = 0;
+          sendRefTime(&pkt_data);
+          pkt_data.reftime = 0;
         }
-        sendStreamPacket(&pkt);
+        sendStreamPacket(&pkt_data);
+      }
+
+      // If some additional data is present inside the stream, it is written there (currently RDS inside MPEG2-Audio)
+      if (pkt_side_data.data)
+      {
+        if (pkt_side_data.streamChange || requestStreamChangeExtData)
+          sendStreamChange();
+        requestStreamChangeExtData = false;
+        if (pkt_side_data.reftime)
+        {
+          sendRefTime(&pkt_side_data);
+          pkt_side_data.reftime = 0;
+        }
+        sendStreamPacket(&pkt_side_data);
+        pkt_side_data.data = NULL;
       }
 
       // send signal info every 10 sec.
@@ -340,6 +361,17 @@ void cLiveStreamer::sendStreamChange()
       resp->add_U32(BlockAlign);
       resp->add_U32(BitRate);
       resp->add_U32(BitsPerSample);
+
+      for (unsigned int i = 0; i < stream->GetSideDataTypes()->size(); i++)
+      {
+        resp->add_U32(stream->GetSideDataTypes()->at(i).first);
+        if (stream->GetSideDataTypes()->at(i).second == scRDS)
+        {
+          resp->add_String("RDS");
+          resp->add_String(stream->GetLanguage());
+          resp->add_U32(stream->GetPID());
+        }
+      }
     }
     else if (stream->Type() == stMPEG2VIDEO)
     {

--- a/streamer.c
+++ b/streamer.c
@@ -40,10 +40,11 @@
 
 // --- cLiveStreamer -------------------------------------------------
 
-cLiveStreamer::cLiveStreamer(int clientID, uint8_t timeshift, uint32_t timeout)
+cLiveStreamer::cLiveStreamer(int clientID, bool bAllowRDS, uint8_t timeshift, uint32_t timeout)
  : cThread("cLiveStreamer stream processor")
  , m_ClientID(clientID)
  , m_scanTimeout(timeout)
+ , m_Demuxer(bAllowRDS)
  , m_VideoInput(m_Event, m_Mutex, m_IsRetune)
 {
   m_Channel         = NULL;
@@ -172,7 +173,7 @@ void cLiveStreamer::Action(void)
   memset(&pkt_data, 0, sizeof(sStreamPacket));
   memset(&pkt_side_data, 0, sizeof(sStreamPacket));
   bool requestStreamChangeStdData = false;
-  bool requestStreamChangeExtData= false;
+  bool requestStreamChangeExtData = false;
   cTimeMs last_info(1000);
   cTimeMs bufferStatsTimer(1000);
 

--- a/streamer.h
+++ b/streamer.h
@@ -90,7 +90,7 @@ protected:
   void Close();
 
 public:
-  cLiveStreamer(int clientID, uint8_t timeshift, uint32_t timeout = 0);
+  cLiveStreamer(int clientID, bool bAllowRDS, uint8_t timeshift, uint32_t timeout = 0);
   virtual ~cLiveStreamer();
 
   void Activate(bool On);

--- a/vnsiclient.h
+++ b/vnsiclient.h
@@ -56,6 +56,7 @@ private:
   bool             m_StatusInterfaceEnabled;
   cLiveStreamer   *m_Streamer;
   bool             m_isStreaming;
+  bool             m_bSupportRDS;
   cString          m_ClientAddress;
   cRecPlayer      *m_RecPlayer;
   cRequestPacket  *m_req;

--- a/vnsicommand.h
+++ b/vnsicommand.h
@@ -26,7 +26,10 @@
 #define VNSI_COMMAND_H
 
 /** Current VNSI Protocol Version number */
-#define VNSI_PROTOCOLVERSION 7
+#define VNSI_PROTOCOLVERSION 8
+
+/** Start of RDS support protocol Version */
+#define VNSI_RDS_PROTOCOLVERSION 8
 
 /** Minimum VNSI Protocol Version number */
 #define VNSI_MIN_PROTOCOLVERSION 5


### PR DESCRIPTION
With this request RDS support becomes added to mpeg2 audio on radio channels.

There on second patch becomes also a backword compatibility to use without RDS added.