### PR TITLE
Set PmtTimeout to 0 by default

### DIFF
--- a/setup.c
+++ b/setup.c
@@ -21,7 +21,7 @@
 #include "setup.h"
 #include "vnsicommand.h"
 
-int PmtTimeout = 5;
+int PmtTimeout = 0;
 int TimeshiftMode = 0;
 int TimeshiftBufferSize = 5;
 int TimeshiftBufferFileSize = 6;


### PR DESCRIPTION
As discussed via mail. Should reduce channel switching time a whole lot. Users with issues can increase via the usual config interface.