### PR TITLE
fix RAM timeshift stream corruption

### DIFF
--- a/videobuffer.c
+++ b/videobuffer.c
@@ -303,7 +303,7 @@ int cVideoBufferRAM::ReadBlock(uint8_t **buf, unsigned int size, time_t &endTime
   if (m_ReadPtr > (m_BufferSize - m_Margin))
   {
     int bytesToCopy = m_BufferSize - m_ReadPtr;
-    memmove(m_Buffer + (m_Margin - bytesToCopy), m_Buffer + m_ReadPtr, bytesToCopy);
+    memmove(m_Buffer + (m_Margin - bytesToCopy), m_BufferPtr + m_ReadPtr, bytesToCopy);
     *buf = m_Buffer + (m_Margin - bytesToCopy);
   }
   else


### PR DESCRIPTION
This bug causes video artefacts possibly described in http://forum.kodi.tv/showthread.php?tid=235732. Can be easily reproduced by setting  `m_BufferSize = (off_t)10*1000*1000` in the source (line 226) and switching to a high-bitrate channel.
