### PR TITLE
vnsiclient: "timeout" is optional in ChannelStream_Open()

### DIFF
--- a/vnsiclient.c
+++ b/vnsiclient.c
@@ -757,10 +757,9 @@ bool cVNSIClient::processChannelStream_Open(cRequestPacket &req) /* OPCODE 20 */
   uint32_t uid = req.extract_U32();
   int32_t priority = req.extract_S32();
   uint8_t timeshift = req.extract_U8();
-  uint32_t timeout = req.extract_U32();
-
-  if(timeout == 0)
-    timeout = VNSIServerConfig.stream_timeout;
+  uint32_t timeout = req.end()
+    ? VNSIServerConfig.stream_timeout
+    : req.extract_U32();
 
   if (m_isStreaming)
     StopChannelStreaming();


### PR DESCRIPTION
Current pvr.vdr.vnsi causes the "Malformed VNSI packet" error to be
triggered because it omits the "timeout" in the ChannelStream_Open
packet.  It's hard to tell what's right and what's wrong, because
there is no VNSI protocol definition.  This worked before (due to lack
of error handling), so let's make the "timeout" optional.