### PR TITLE
C++11 requires a mandatory space when concatenating string literals

### DIFF
--- a/config.h
+++ b/config.h
@@ -34,19 +34,19 @@
 // log output configuration
 
 #ifdef CONSOLEDEBUG
-#define DEBUGLOG(x...) printf("VNSI: "x)
+#define DEBUGLOG(x...) printf("VNSI: " x)
 #elif defined  DEBUG
-#define DEBUGLOG(x...) dsyslog("VNSI: "x)
+#define DEBUGLOG(x...) dsyslog("VNSI: " x)
 #else
 #define DEBUGLOG(x...)
 #endif
 
 #ifdef CONSOLEDEBUG
-#define INFOLOG(x...) printf("VNSI: "x)
-#define ERRORLOG(x...) printf("VNSI-Error: "x)
+#define INFOLOG(x...) printf("VNSI: " x)
+#define ERRORLOG(x...) printf("VNSI-Error: " x)
 #else
-#define INFOLOG(x...) isyslog("VNSI: "x)
-#define ERRORLOG(x...) esyslog("VNSI-Error: "x)
+#define INFOLOG(x...) isyslog("VNSI: " x)
+#define ERRORLOG(x...) esyslog("VNSI-Error: " x)
 #endif
 
 // default settings


### PR DESCRIPTION
This issue came up with GCC6. Concatenating string literals now requires a space in between.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=811949