### PR TITLE
vnsiclient: fix thread shutdown

### DIFF
--- a/vnsiclient.c
+++ b/vnsiclient.c
@@ -76,8 +76,9 @@ cVNSIClient::~cVNSIClient()
   DEBUGLOG("%s", __FUNCTION__);
   StopChannelStreaming();
   m_ChannelScanControl.StopScan();
-  m_socket.close(); // force closing connection
+  m_socket.Shutdown();
   Cancel(10);
+  m_socket.close();
   DEBUGLOG("done");
 }
 

--- a/vnsiserver.c
+++ b/vnsiserver.c
@@ -82,8 +82,8 @@ cVNSIServer::cVNSIServer(int listenPort) : cThread("VDR VNSI Server")
 
 cVNSIServer::~cVNSIServer()
 {
-  m_Status.Shutdown();
   Cancel();
+  m_Status.Shutdown();
   INFOLOG("VNSI Server stopped");
 }
 


### PR DESCRIPTION
This fixes annoying 10 sec VDR shutdown which sometimes causes KODI crashes.