### PR TITLE
Fixed malformed SIGNALINFO packet in streamer

### DIFF
--- a/streamer.c
+++ b/streamer.c
@@ -614,6 +614,12 @@ void cLiveStreamer::sendSignalInfo()
         case cSource::stTerr:
           resp.add_String(*cString::sprintf("DVB-T #%d - %s", cDevice::ActualDevice()->CardIndex(), m_FrontendInfo.name));
           break;
+        case cSource::stAtsc:
+          resp->add_String(*cString::sprintf("ATSC #%d - %s", cDevice::ActualDevice()->CardIndex(), m_FrontendInfo.name));
+          break;
+        default:
+          resp->add_U8(0);
+          break;
       }
       resp.add_String(*cString::sprintf("%s:%s:%s:%s:%s", (status & FE_HAS_LOCK) ? "LOCKED" : "-", (status & FE_HAS_SIGNAL) ? "SIGNAL" : "-", (status & FE_HAS_CARRIER) ? "CARRIER" : "-", (status & FE_HAS_VITERBI) ? "VITERBI" : "-", (status & FE_HAS_SYNC) ? "SYNC" : "-"));
       resp.add_U32(fe_snr);


### PR DESCRIPTION
ATSC sources should append a device name to the signal info. For
unidentified/future source types, we should at least add a null byte so
that clients can properly parse out its fields.