### PR TITLE
Avoid division by zero on BBC-SATBACK channels (27.5W)

### DIFF
--- a/parser_AAC.c
+++ b/parser_AAC.c
@@ -154,6 +154,9 @@ int cParserAAC::FindHeaders(uint8_t *buf, int buf_size)
       m_FrameSize = bs.readBits(13);
       m_SampleRate    = aac_sample_rates[SampleRateIndex & 0x0E];
 
+      if (!m_SampleRate)
+        m_SampleRate = aac_sample_rates[4];
+
       m_FoundFrame = true;
       m_DTS = m_curPTS;
       m_PTS = m_curPTS;


### PR DESCRIPTION
HD channels at 27.5W / 11495 V contain HE-AAC audio, which makes this plugin crash on division by zero:

```
Thread 36 "cLiveStreamer s" received signal SIGFPE, Arithmetic exception.
[Switching to Thread 0x7f49c17fa700 (LWP 30618)]
0x00007f4a34cd19d9 in cParserAAC::FindHeaders (this=0x7f49a4003110,
    buf=0x7f49a403dbf9 "\377\377\372`\b\360\241d\245\330`\314\364\030\006[B\034\r5\023.f\221V\005*\350W'\347\374w;\223\216\320\360\271?D퐹\303\034VU\\\330w;э5)\377E\216\207*\262\071U;X\312\032C\033\306\061B\347\350\246H\254&~\a\313?Y\nn\302\345 \025-\212\370$F:{ު\324{#\r\332\324J̌\376\060 
\253K\240\037;\216\254\020kȜʋ\353\fK:\254\236\021\022/\307\021;\246\206\300ʕ%;\254\031\200$\260.\226kM\r\350gf\224!l", buf_size=159) at parser_AAC.c:160
warning: Source file is more recent than executable.
160           m_curPTS += 90000 * 1024 / m_SampleRate;
(gdb) bt
#0  0x00007f4a34cd19d9 in cParserAAC::FindHeaders (this=0x7f49a4003110,
    buf=0x7f49a403dbf9 "\377\377\372`\b\360\241d\245\330`\314\364\030\006[B\034\r5\023.f\221V\005*\350W'\347\374w;\223\216\320\360\271?D퐹\303\034VU\\\330w;э5)\377E\216\207*\262\071U;X\312\032C\033\306\061B\347\350\246H\254&~\a\313?Y\nn\302\345 \025-\212\370$F:{ު\324{#\r\332\324J̌\376\060 
\253K\240\037;\216\254\020kȜʋ\353\fK:\254\236\021\022/\307\021;\246\206\300ʕ%;\254\031\200$\260.\226kM\r\350gf\224!l", buf_size=159) at parser_AAC.c:160
#1  0x00007f4a34cd14a7 in cParserAAC::Parse (this=0x7f49a4003110, pkt=0x7f49c17f9e50, pkt_side_data=0x7f49c17f9e90) at parser_AAC.c:71
#2  0x00007f4a34ccf980 in cTSStream::ProcessTSPacket (this=0x7f49a4000a70, data=0x7f4a180fe1f0 "GW\326;\001@", pkt=0x7f49c17f9e50, pkt_side_data=0x7f49c17f9e90, iframe=true) at parser.c:558
#3  0x00007f4a34ce3005 in cVNSIDemuxer::Read (this=0x7f49b8000cf8, packet=0x7f49c17f9e50, packet_side_data=0x7f49c17f9e90) at demuxer.c:136
#4  0x00007f4a34cd73c2 in cLiveStreamer::Action (this=0x7f49b8000b30) at streamer.c:195
#5  0x0000000000507f69 in cThread::StartThread(cThread*) ()
#6  0x00007f4a3b397484 in start_thread () from /lib64/libpthread.so.0
#7  0x00007f4a39ccae7d in clone () from /lib64/libc.so.6
(gdb) p SampleRateIndex
$1 = 14
```

My trivial commit "copies" a similar division by zero avoidance from other places in the source file.