### PR TITLE
Retune fixes

### DIFF
--- a/streamer.h
+++ b/streamer.h
@@ -32,7 +32,6 @@
 #include <vdr/device.h>
 #include <vdr/receiver.h>
 #include <vdr/thread.h>
-#include <list>
 
 #include "parser.h"
 #include "responsepacket.h"
@@ -49,8 +48,6 @@ class cVideoInput;
 class cLiveStreamer : public cThread
 {
   friend class cParser;
-  friend class cLivePatFilter;
-  friend class cLiveReceiver;
 
   void sendStreamPacket(sStreamPacket *pkt);
   void sendStreamChange();
@@ -80,9 +77,7 @@ class cLiveStreamer : public cThread
   cVideoInput       m_VideoInput;
   int               m_Priority;
   uint8_t           m_Timeshift;
-  cCondVar          m_Event;
-  cMutex            m_Mutex;
-  bool              m_IsRetune = false;
+  cCondWait         m_Event;
 
 protected:
   virtual void Action(void);

--- a/videoinput.c
+++ b/videoinput.c
@@ -558,6 +558,9 @@ void cVideoInput::Close()
       cCamSlot *cs = m_Device->CamSlot();
       if (cs)
         cs->CancelActivation();
+      if (m_Receiver)
+        ChannelCamRelations.ClrChecked(m_Receiver->ChannelID(),
+                (cs)? cs->SlotNumber() : 0);
     }
 #endif
 

--- a/videoinput.h
+++ b/videoinput.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vdr/channels.h>
 #include <vdr/thread.h>
 
@@ -31,22 +32,24 @@ class cLivePatFilter;
 class cLiveReceiver;
 class cVideoBuffer;
 class cDevice;
+class cDummyReceiver;
 
 class cVideoInput
 {
 friend class cLivePatFilter;
 friend class cLiveReceiver;
 public:
-  cVideoInput(cCondVar &condVar, cMutex &mutex, bool &retune);
+  cVideoInput(cCondWait &event);
   virtual ~cVideoInput();
   bool Open(const cChannel *channel, int priority, cVideoBuffer *videoBuffer);
   void Close();
   bool IsOpen();
-
+  void RequestRetune();
+  enum eReceivingStatus {NORMAL, RETUNE, CLOSE};
+  eReceivingStatus ReceivingStatus();
 protected:
   cChannel *PmtChannel();
   void Receive(const uchar *data, int length);
-  void Retune();
   cDevice          *m_Device;
   cLivePatFilter   *m_PatFilter;
   cLiveReceiver    *m_Receiver;
@@ -54,8 +57,8 @@ protected:
   cVideoBuffer     *m_VideoBuffer;
   int               m_Priority;
   bool              m_PmtChange;
-  cCondVar          &m_Event;
-  cMutex            &m_Mutex;
-  bool              &m_IsRetune;
   cChannel m_PmtChannel;
+  cCondWait &m_Event;
+  std::shared_ptr<cDummyReceiver> m_DummyReceiver;
+  bool m_RetuneRequested;
 };


### PR DESCRIPTION
This PR fixes two issues with re-tune:

1.  When a higher priority recording or streaming task is about to zap to another transponder on the device from which VNSI is currently streaming, it detaches all receivers from the device, which, in turn, triggers re-tune. Since VDR has no synchronization mechanism for zapping (`GetDevice()->SwitchChannel()->AttachReceiver()` chain), a race occurs. The result is usually that the recording calls an emergency exit after not receiving TS packets for 30 seconds. To reproduce this, start streaming a channel, then start recording (or another VNSI streaming with a higher priority) of a channel from another transponder. VDR should restart in 30 seconds. The proposed solution is to disable re-tune in such cases. Even if (when) VDR had zapping synchronization, re-tuning after the device has been switched to another transponder by a higher priority task wouldn't be practical anyway.
To detect whether to re-tune or not, a helper dummy receiver is attached to the device. If this dummy receiver is detached, re-tuning should be disabled.

2.  `DisableScrambleTimeout` option only works for clients with priority < 0 (after 9a8fef72 it's not possible anymore). For CAMs like dvbapi, re-tuning after scrambling timeout has expired doesn't help because the channel is then being marked 'checked' (blacklisted) for 15 seconds. To reproduce this, add a delay > 3 seconds to the CAM, or switch it off, and, after some time, switch it on. Solution: 'uncheck' before zapping (`GetDevice()` call).