### PR TITLE
cVideoInput: make bool flags atomic

### DIFF
--- a/videoinput.c
+++ b/videoinput.c
@@ -82,9 +82,9 @@ void cLiveReceiver::Receive(uchar *Data, int Length)
 
 void cLiveReceiver::Activate(bool On)
 {
-  INFOLOG("activate live receiver: %d, pmt change: %d", On, m_VideoInput->m_PmtChange);
-  if (!On)
-    m_VideoInput->m_Event.Signal();
+  INFOLOG("activate live receiver: %d, pmt change: %d", On, static_cast<bool>(m_VideoInput->m_PmtChange));
+  if (!On && !m_VideoInput->m_PmtChange)
+    m_VideoInput->RequestRetune();
 }
 
 // --- cLivePatFilter ----------------------------------------------------
@@ -425,6 +425,7 @@ public:
   // Return a new or existing dummy receiver attached to the device.
   static std::shared_ptr<cDummyReceiver> Create(cDevice *device);
   virtual ~cDummyReceiver() {Detach();}
+  bool BeenDetached() {return m_BeenDetached;}
 protected:
 #if VDRVERSNUM >= 20301
   virtual void Receive(const uchar *Data, int Length) {}
@@ -435,7 +436,8 @@ protected:
 private:
   static std::vector<std::weak_ptr<cDummyReceiver>> s_Pool;
   static cMutex s_PoolMutex;
-  cDummyReceiver() : cReceiver(NULL, MINPRIORITY) {}
+  std::atomic<bool> m_BeenDetached;
+  cDummyReceiver() : cReceiver(NULL, MINPRIORITY), m_BeenDetached(false) {}
 };
 
 std::vector<std::weak_ptr<cDummyReceiver>> cDummyReceiver::s_Pool;
@@ -444,6 +446,8 @@ cMutex cDummyReceiver::s_PoolMutex;
 void cDummyReceiver::Activate(bool On)
 {
   INFOLOG("Dummy receiver (%p) %s", this, (On)? "activated" : "deactivated");
+  if (!On)
+    m_BeenDetached = true;
 }
 
 std::shared_ptr<cDummyReceiver> cDummyReceiver::Create(cDevice *device)
@@ -461,7 +465,7 @@ std::shared_ptr<cDummyReceiver> cDummyReceiver::Create(cDevice *device)
   for (auto p : s_Pool)
   {
     auto recv = p.lock();
-    if (recv->Device() == device)
+    if (!recv->BeenDetached() && recv->Device() == device)
       return recv;
   }
   auto recv = std::shared_ptr<cDummyReceiver>(new cDummyReceiver);
@@ -476,7 +480,9 @@ std::shared_ptr<cDummyReceiver> cDummyReceiver::Create(cDevice *device)
 // ----------------------------------------------------------------------------
 
 cVideoInput::cVideoInput(cCondWait &event)
-  : m_Event(event)
+  : m_PmtChange(false)
+  , m_Event(event)
+  , m_RetuneRequested(false)
 {
   m_Device = NULL;;
   m_PatFilter = NULL;
@@ -484,8 +490,6 @@ cVideoInput::cVideoInput(cCondWait &event)
   m_Channel = NULL;
   m_VideoBuffer = NULL;
   m_Priority = 0;
-  m_PmtChange = false;
-  m_RetuneRequested = false;
 }
 
 cVideoInput::~cVideoInput()
@@ -499,6 +503,7 @@ bool cVideoInput::Open(const cChannel *channel, int priority, cVideoBuffer *vide
   m_Channel = channel;
   m_Priority = priority;
   m_RetuneRequested = false;
+  m_PmtChange = false;
   m_Device = cDevice::GetDevice(m_Channel, m_Priority, false);
 
   if (m_Device != NULL)
@@ -643,14 +648,14 @@ void cVideoInput::RequestRetune()
 
 cVideoInput::eReceivingStatus cVideoInput::ReceivingStatus()
 {
-  if (!m_Device || !m_Receiver || !m_DummyReceiver)
+  if (!m_Device || !m_DummyReceiver)
     return RETUNE;
-  if (m_RetuneRequested || !m_Receiver->IsAttached())
+  if (m_RetuneRequested)
   {
     (void)m_Device->Receiving();  // wait for the receivers mutex
-    if (!m_DummyReceiver->IsAttached())  // DetachAllReceivers() was called
+    if (m_DummyReceiver->BeenDetached())  // DetachAllReceivers() was called
       return CLOSE;
-    else if (!m_PmtChange)
+    else
       return RETUNE;
   }
   return NORMAL;

--- a/videoinput.h
+++ b/videoinput.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <memory>
+#include <atomic>
 #include <vdr/channels.h>
 #include <vdr/thread.h>
 
@@ -56,9 +57,9 @@ protected:
   const cChannel   *m_Channel;
   cVideoBuffer     *m_VideoBuffer;
   int               m_Priority;
-  bool              m_PmtChange;
+  std::atomic<bool> m_PmtChange;
   cChannel m_PmtChannel;
   cCondWait &m_Event;
   std::shared_ptr<cDummyReceiver> m_DummyReceiver;
-  bool m_RetuneRequested;
+  std::atomic<bool> m_RetuneRequested;
 };


### PR DESCRIPTION
@FernetMenta Pls review. `m_PmtChange` is checked in `cLiveReceiver::Activate()` callback as it was before 55500d3. It means that if `m_Receiver` is detached before the very first call to `cVideoInput::Receive()` (while `m_PmtChange` is true), this detach will not be noticed, and re-tune can only be triggered from the *outside* later, using explicit `cVideoInput::RequestRetune()` call. Is that OK?
