### PR TITLE
Some cVideoInput cleanup

### DIFF
--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VNSI-Server 1.0.0\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2016-04-23 09:08+0200\n"
+"POT-Creation-Date: 2016-09-26 21:50+0300\n"
 "PO-Revision-Date: 2015-01-23 21:46+0100\n"
 "Last-Translator: Alwin Esch\n"
 "Language-Team: German\n"
@@ -49,6 +49,9 @@ msgid "Avoid EPG scan while streaming"
 msgstr "Keine EPG suche während der Wiedergabe durchführen"
 
 msgid "Disable scramble timeout"
+msgstr ""
+
+msgid "Disable cam blacklist"
 msgstr ""
 
 msgid "Recording with the same name exists"

--- a/po/lt_LT.po
+++ b/po/lt_LT.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VNSI-Server 1.0.0\n"
 "Report-Msgid-Bugs-To: <see README>\n"
-"POT-Creation-Date: 2016-04-23 09:08+0200\n"
+"POT-Creation-Date: 2016-09-26 21:50+0300\n"
 "PO-Revision-Date: 2015-02-11 22:30+0200\n"
 "Last-Translator: Valdemaras Pipiras\n"
 "Language-Team: Lithuanian\n"
@@ -49,6 +49,9 @@ msgid "Avoid EPG scan while streaming"
 msgstr "Vengti EPG skanavimo kol vyksta transliacija"
 
 msgid "Disable scramble timeout"
+msgstr ""
+
+msgid "Disable cam blacklist"
 msgstr ""
 
 msgid "Recording with the same name exists"

--- a/videoinput.h
+++ b/videoinput.h
@@ -59,7 +59,7 @@ protected:
   const cChannel   *m_Channel;
   cVideoBuffer     *m_VideoBuffer;
   int               m_Priority;
-  std::atomic<bool> m_PmtChange;
+  bool              m_DataSeen;
   cChannel m_PmtChannel;
   cCondWait &m_Event;
   std::shared_ptr<cDummyReceiver> m_DummyReceiver;


### PR DESCRIPTION
Now re-tunes can be triggered by cLiveReceiver detach if no TS packet has been seen yet. Though, re-tunes don't help with [this issue](https://github.com/FernetMenta/vdr-plugin-vnsiserver/pull/74#issuecomment-249086037) because startScrambleDetection is far in the past, and cLiveReceiver is detached immediately on each try.