### PR TITLE
Fix building against musl C library

### DIFF
--- a/vnsiosd.c
+++ b/vnsiosd.c
@@ -29,7 +29,7 @@
 #include "vnsi.h"
 #include <signal.h>
 #include <sys/ioctl.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 #include <vdr/tools.h>
 #include <vdr/remote.h>
 #include "cxsocket.h"


### PR DESCRIPTION
Musl doesn't have `sys/unistd.h` file, and the one from glibc simply does `#include <unistd.h>`.