### PR TITLE
Fix "Play Recording instead of live" EOF detection

### DIFF
--- a/videobuffer.c
+++ b/videobuffer.c
@@ -618,6 +618,7 @@ public:
   virtual void Put(const uint8_t *buf, unsigned int size);
   virtual int ReadBlock(uint8_t **buf, unsigned int size, time_t &endTime, time_t &wrapTime);
   virtual time_t GetRefTime();
+  virtual void AttachInput(bool attach);
 
 protected:
   cVideoBufferRecording(const cRecording *rec);
@@ -680,6 +681,11 @@ bool cVideoBufferRecording::Init()
 time_t cVideoBufferRecording::GetRefTime()
 {
   return m_Recording->Start();
+}
+
+void cVideoBufferRecording::AttachInput(bool attach)
+{
+
 }
 
 off_t cVideoBufferRecording::Available()

--- a/videobuffer.h
+++ b/videobuffer.h
@@ -48,7 +48,7 @@ public:
   virtual bool HasBuffer() { return false; };
   virtual time_t GetRefTime();
   int Read(uint8_t **buf, unsigned int size, time_t &endTime, time_t &wrapTime);
-  void AttachInput(bool attach);
+  virtual void AttachInput(bool attach);
 protected:
   cVideoBuffer();
   cTimeMs m_Timer;


### PR DESCRIPTION
When using "Play Recording instead of live" video stream stalls at end of recording.

Setting cVideoBuffer::m_InputAttached via cVideoBuffer::AttachInput() prevents EOF detection in cVideoBuffer::Read(). 
