### PR TITLE
Make cParserMPEG2Video::m_FrameDuration 64bit

### DIFF
--- a/parser_MPEGVideo.h
+++ b/parser_MPEGVideo.h
@@ -38,7 +38,7 @@ private:
   uint32_t        m_StartCode;
   bool            m_NeedIFrame;
   bool            m_NeedSPS;
-  int             m_FrameDuration;
+  int64_t         m_FrameDuration;
   int             m_vbvDelay;       /* -1 if CBR */
   int             m_vbvSize;        /* Video buffer size (in bytes) */
   int             m_Width;


### PR DESCRIPTION
Compiling with -W shows:
```
In file included from parser_MPEGVideo.h:29:0,
                 from parser_MPEGVideo.c:25:
parser_MPEGVideo.c: In member function ‘virtual void cParserMPEG2Video::Parse(sStreamPacket*, sStreamPacket*)’:
parser.h:33:37: warning: comparison is always true due to limited range of data type [-Wtype-limits]
 #define DVD_NOPTS_VALUE    (-1LL<<52) // should be possible to represent in both double and
                                     ^
parser_MPEGVideo.c:103:32: note: in expansion of macro ‘DVD_NOPTS_VALUE’
         if (m_FrameDuration != DVD_NOPTS_VALUE)
```