### PR TITLE
Fix segfault when undelete recordings

### DIFF
--- a/vnsiclient.h
+++ b/vnsiclient.h
@@ -150,7 +150,7 @@ protected:
   bool processSCAN_Start(cRequestPacket &r);
   bool processSCAN_Stop(cRequestPacket &r);
 
-  bool Undelete(cRecording* recording);
+  bool Undelete(cRecording* recording, cRecordings* reclist, cRecordings* dellist);
 
   bool processOSD_Connect(cRequestPacket &req);
   bool processOSD_Disconnect();


### PR DESCRIPTION
VDR 2.4.0: using LOCK_DELETEDRECORDINGS_WRITE twice results in `DeletedRecordings==nullptr`

PR is only build tested with VDR 2.2.0